### PR TITLE
Feat: DNS - Route53, ACM, ALB-HTTPS

### DIFF
--- a/alb.tf
+++ b/alb.tf
@@ -102,29 +102,24 @@ resource "aws_alb_listener" "alb_main_listener_http" {
   protocol = "HTTP"
 
   default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_alb_listener" "alb_main_listener_https" {
+  load_balancer_arn = aws_alb.alb_main.arn
+  port = 443
+  protocol = "HTTPS"
+  certificate_arn = aws_acm_certificate_validation.hz_main_cert_validate.certificate_arn
+
+  default_action {
     type = "forward"
     target_group_arn = aws_alb_target_group.alb_main_tg_api.arn
   }
-
-# TODO: TLS Cert setting
-#   default_action {
-#     type = "redirect"
-#
-#     redirect {
-#       port        = "443"
-#       protocol    = "HTTPS"
-#       status_code = "HTTP_301"
-#     }
-#   }
-#
-# resource "aws_alb_listener" "alb_main_listener_https" {
-#   load_balancer_arn = aws_alb.alb_main.arn
-#   port = 443
-#   protocol = "HTTPS"
-#
-#   default_action {
-#     type = "forward"
-#     target_group_arn = aws_alb_target_group.alb_main_tg_api.arn
-#   }
-# }
 }

--- a/alb.tf
+++ b/alb.tf
@@ -2,9 +2,9 @@
 #D SG for LB accepts only HTTP and HTTPS connections
 #D And ignore all other in/egresses
 resource "aws_security_group" "sg_alb" {
-  name = "elon-kiosk-lb-sg"
+  name        = "elon-kiosk-lb-sg"
   description = "Load Balancer Security Group"
-  vpc_id = aws_vpc.vpc_main.id
+  vpc_id      = aws_vpc.vpc_main.id
 
   tags = {
     Name = "elon-kiosk-lb-sg"
@@ -68,38 +68,38 @@ resource "aws_security_group_rule" "sg_alb_rule_eg_https" {
 
 # ALB
 resource "aws_alb" "alb_main" {
-  name = "elon-kiosk-alb"
-  internal = false
+  name               = "elon-kiosk-alb"
+  internal           = false
   load_balancer_type = "application"
-  security_groups = [ aws_security_group.sg_alb.id ]
-  subnets = [ aws_subnet.pub_subnet_az1.id, aws_subnet.pub_subnet_az2.id ]
+  security_groups    = [aws_security_group.sg_alb.id]
+  subnets            = [aws_subnet.pub_subnet_az1.id, aws_subnet.pub_subnet_az2.id]
 }
 
 ## Target Group
 resource "aws_alb_target_group" "alb_main_tg_api" {
-  name = "elon-kiosk-alb-tg"
-  port = var.apiserver_port
+  name     = "elon-kiosk-alb-tg"
+  port     = var.apiserver_port
   protocol = "HTTP"
-  vpc_id = aws_vpc.vpc_main.id
+  vpc_id   = aws_vpc.vpc_main.id
 }
 
 resource "aws_alb_target_group_attachment" "alb_main_tg_api_attach_az1" {
   target_group_arn = aws_alb_target_group.alb_main_tg_api.arn
-  target_id = aws_instance.apiserver_az1.id
-  port = var.apiserver_port
+  target_id        = aws_instance.apiserver_az1.id
+  port             = var.apiserver_port
 }
 
 resource "aws_alb_target_group_attachment" "alb_main_tg_api_attach_az2" {
   target_group_arn = aws_alb_target_group.alb_main_tg_api.arn
-  target_id = aws_instance.apiserver_az2.id
-  port = var.apiserver_port
+  target_id        = aws_instance.apiserver_az2.id
+  port             = var.apiserver_port
 }
 
 ## Listeners
 resource "aws_alb_listener" "alb_main_listener_http" {
   load_balancer_arn = aws_alb.alb_main.arn
-  port = 80
-  protocol = "HTTP"
+  port              = 80
+  protocol          = "HTTP"
 
   default_action {
     type = "redirect"
@@ -114,12 +114,12 @@ resource "aws_alb_listener" "alb_main_listener_http" {
 
 resource "aws_alb_listener" "alb_main_listener_https" {
   load_balancer_arn = aws_alb.alb_main.arn
-  port = 443
-  protocol = "HTTPS"
-  certificate_arn = aws_acm_certificate_validation.hz_main_cert_validate.certificate_arn
+  port              = 443
+  protocol          = "HTTPS"
+  certificate_arn   = aws_acm_certificate_validation.hz_main_cert_validate.certificate_arn
 
   default_action {
-    type = "forward"
+    type             = "forward"
     target_group_arn = aws_alb_target_group.alb_main_tg_api.arn
   }
 }

--- a/api-server.tf
+++ b/api-server.tf
@@ -27,9 +27,9 @@ data "aws_ami" "amazonLinux" {
 
 # SG
 resource "aws_security_group" "sg_apiserver" {
-  name = "elon-kiosk-api-sg"
+  name        = "elon-kiosk-api-sg"
   description = "API Server Security Group"
-  vpc_id = aws_vpc.vpc_main.id
+  vpc_id      = aws_vpc.vpc_main.id
 
   tags = {
     Name = "elon-kiosk-api-sg"
@@ -39,12 +39,12 @@ resource "aws_security_group" "sg_apiserver" {
 ## SG Rules
 ### Ingress
 resource "aws_security_group_rule" "sg_apiserver_rule_ing_http" {
-  type              = "ingress"
-  from_port         = var.apiserver_port
-  to_port           = var.apiserver_port
-  protocol          = "TCP"
+  type                     = "ingress"
+  from_port                = var.apiserver_port
+  to_port                  = var.apiserver_port
+  protocol                 = "TCP"
   source_security_group_id = aws_security_group.sg_alb.id
-  security_group_id = aws_security_group.sg_apiserver.id
+  security_group_id        = aws_security_group.sg_apiserver.id
 
   lifecycle {
     create_before_destroy = true
@@ -117,10 +117,10 @@ resource "aws_instance" "apiserver_az2" {
 # This instance is intended to use as a SSH tunnel to the API server instance
 # Should be deleted in production environment
 resource "aws_instance" "tunnel" {
-  ami           = data.aws_ami.amazonLinux.id
-  instance_type = "t2.micro"
-  subnet_id = aws_subnet.pub_subnet_az1.id
-  key_name  = "elon-kiosk-ssh-pubkey"
+  ami                         = data.aws_ami.amazonLinux.id
+  instance_type               = "t2.micro"
+  subnet_id                   = aws_subnet.pub_subnet_az1.id
+  key_name                    = "elon-kiosk-ssh-pubkey"
   associate_public_ip_address = true
 
   vpc_security_group_ids = [

--- a/dns.tf
+++ b/dns.tf
@@ -28,9 +28,9 @@ resource "aws_route53_record" "hz_main_record_soa" {
 
 # ACM
 resource "aws_acm_certificate" "hz_main_cert" {
-  domain_name       = var.hz_main_name
+  domain_name               = var.hz_main_name
   subject_alternative_names = [format("*.%s", var.hz_main_name)]
-  validation_method = "DNS"
+  validation_method         = "DNS"
 }
 
 ## ACM Validation Record
@@ -60,7 +60,7 @@ resource "aws_acm_certificate_validation" "hz_main_cert_validate" {
 ## ALB Alias Record
 resource "aws_route53_record" "hz_main_record_alb" {
   zone_id = aws_route53_zone.hz_main.zone_id
-  name = format("elon-kiosk.%s", var.hz_main_name)
+  name    = format("elon-kiosk.%s", var.hz_main_name)
   type    = "A"
 
   alias {

--- a/dns.tf
+++ b/dns.tf
@@ -1,0 +1,71 @@
+# Hosted Zone
+resource "aws_route53_zone" "hz_main" {
+  name = var.hz_main_name
+}
+
+resource "aws_route53_record" "hz_main_record_ns" {
+  name = var.hz_main_name
+  records = [
+    "ns-1266.awsdns-30.org.",
+    "ns-130.awsdns-16.com.",
+    "ns-2005.awsdns-58.co.uk.",
+    "ns-654.awsdns-17.net.",
+  ]
+  ttl     = 172800
+  type    = "NS"
+  zone_id = aws_route53_zone.hz_main.zone_id
+}
+
+resource "aws_route53_record" "hz_main_record_soa" {
+  name = var.hz_main_name
+  records = [
+    "ns-2005.awsdns-58.co.uk. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400",
+  ]
+  ttl     = 900
+  type    = "SOA"
+  zone_id = aws_route53_zone.hz_main.zone_id
+}
+
+# ACM
+resource "aws_acm_certificate" "hz_main_cert" {
+  domain_name       = var.hz_main_name
+  subject_alternative_names = [format("*.%s", var.hz_main_name)]
+  validation_method = "DNS"
+}
+
+## ACM Validation Record
+resource "aws_route53_record" "hz_main_record_certverify" {
+  for_each = {
+    for dvo in aws_acm_certificate.hz_main_cert.domain_validation_options : dvo.domain_name => {
+      name    = dvo.resource_record_name
+      record  = dvo.resource_record_value
+      type    = dvo.resource_record_type
+      zone_id = aws_route53_zone.hz_main.zone_id
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = each.value.zone_id
+}
+
+resource "aws_acm_certificate_validation" "hz_main_cert_validate" {
+  certificate_arn         = aws_acm_certificate.hz_main_cert.arn
+  validation_record_fqdns = [for record in aws_route53_record.hz_main_record_certverify : record.fqdn]
+}
+
+## ALB Alias Record
+resource "aws_route53_record" "hz_main_record_alb" {
+  zone_id = aws_route53_zone.hz_main.zone_id
+  name = format("elon-kiosk.%s", var.hz_main_name)
+  type    = "A"
+
+  alias {
+    name                   = aws_alb.alb_main.dns_name
+    zone_id                = aws_alb.alb_main.zone_id
+    evaluate_target_health = true
+  }
+}

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,1 +1,2 @@
 apiserver_port = 3000
+hz_main_name = "saltwalks-devel.cloud"

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,2 +1,2 @@
 apiserver_port = 3000
-hz_main_name = "saltwalks-devel.cloud"
+hz_main_name   = "saltwalks-devel.cloud"

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,7 @@
 variable "apiserver_port" {
   type = number
 }
+
+variable "hz_main_name" {
+  type = string
+}


### PR DESCRIPTION
## New Features

- Import Route53 hosted zone: `saltwalks-devel.cloud`
- Import ACM certificate
- ALB record for main hosted zone
- ALB-HTTPS listener

## Modifications

- Redirect HTTP to HTTPS
- Obey `terraform fmt`

## Related Issue

- Closes #8