### PR TITLE
Feat: serving contents

### DIFF
--- a/cdn.tf
+++ b/cdn.tf
@@ -30,10 +30,10 @@ resource "aws_cloudfront_function" "fe_func_replace_request_uri" {
 
 ## Distributions
 resource "aws_cloudfront_distribution" "fe_distribution" {
-  aliases = [format("elon-kiosk.%s", var.hz_main_name)]
-  enabled             = true
-  is_ipv6_enabled     = true
-  price_class = "PriceClass_200"
+  aliases         = [format("elon-kiosk.%s", var.hz_main_name)]
+  enabled         = true
+  is_ipv6_enabled = true
+  price_class     = "PriceClass_200"
 
   restrictions {
     geo_restriction {
@@ -55,10 +55,10 @@ resource "aws_cloudfront_distribution" "fe_distribution" {
     origin_id   = aws_alb.alb_main.id
 
     custom_origin_config {
-      http_port = 80
-      https_port = 443
+      http_port              = 80
+      https_port             = 443
       origin_protocol_policy = "match-viewer"
-      origin_ssl_protocols = ["TLSv1.2"]
+      origin_ssl_protocols   = ["TLSv1.2"]
     }
   }
 
@@ -70,8 +70,8 @@ resource "aws_cloudfront_distribution" "fe_distribution" {
     target_origin_id = aws_alb.alb_main.id
 
     forwarded_values {
-      query_string = true # Forward all query_string
-      headers = ["*"] # Forward all headers
+      query_string = true  # Forward all query_string
+      headers      = ["*"] # Forward all headers
 
       cookies {
         forward = "all" # Forward all cookies
@@ -160,14 +160,14 @@ resource "aws_cloudfront_distribution" "fe_distribution" {
 
   # SPA support: 404 handling
   custom_error_response {
-    error_code = 404
-    response_code = 200
+    error_code         = 404
+    response_code      = 200
     response_page_path = "/index.html"
   }
 
   custom_error_response {
-    error_code = 403
-    response_code = 200
+    error_code         = 403
+    response_code      = 200
     response_page_path = "/index.html"
   }
 }

--- a/cdn.tf
+++ b/cdn.tf
@@ -14,28 +14,91 @@ resource "aws_acm_certificate_validation" "global_cert_validate" {
 }
 
 # CloudFront Distribution
-resource "aws_cloudfront_origin_access_identity" "fe_oai" {
+## OAIs
+resource "aws_cloudfront_origin_access_identity" "fe_customer_oai" {
+}
+
+resource "aws_cloudfront_origin_access_identity" "fe_store_oai" {
 }
 
 resource "aws_cloudfront_distribution" "fe_distribution" {
-  origin {
-    domain_name = aws_s3_bucket.webview_bucket.bucket_domain_name
-    origin_id   = aws_s3_bucket.webview_bucket.id
-    origin_path = "/customer"
-
-    s3_origin_config {
-      origin_access_identity = aws_cloudfront_origin_access_identity.fe_oai.cloudfront_access_identity_path
-    }
-  }
-
   enabled             = true
   is_ipv6_enabled     = true
   default_root_object = "index.html"
+  price_class = "PriceClass_200"
 
-  default_cache_behavior {
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn = aws_acm_certificate.global_cert.arn
+    ssl_support_method  = "sni-only"
+  }
+
+  # S3 Origin: customer webview bucket
+  origin {
+    domain_name = aws_s3_bucket.wv_customer_bucket.bucket_domain_name
+    origin_id   = aws_s3_bucket.wv_customer_bucket.id
+
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.fe_customer_oai.cloudfront_access_identity_path
+    }
+  }
+
+  # S3 Origin: store webview bucket
+  origin {
+    domain_name = aws_s3_bucket.wv_store_bucket.bucket_domain_name
+    origin_id   = aws_s3_bucket.wv_store_bucket.id
+
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.fe_store_oai.cloudfront_access_identity_path
+    }
+  }
+
+  # ALB origin
+  origin {
+    domain_name = aws_alb.alb_main.dns_name
+    origin_id   = aws_alb.alb_main.id
+
+    custom_origin_config {
+      http_port = 80
+      https_port = 443
+      origin_protocol_policy = "match-viewer"
+      origin_ssl_protocols = ["TLSv1.2"]
+    }
+  }
+
+  # ALB behavior (precedence 0)
+  ordered_cache_behavior {
+    path_pattern     = "/api*"
     allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
     cached_methods   = ["GET", "HEAD"]
-    target_origin_id = aws_s3_bucket.webview_bucket.id
+    target_origin_id = aws_alb.alb_main.id
+
+    forwarded_values {
+      query_string = true # Forward all query_string
+      headers = ["*"] # Forward all headers
+
+      cookies {
+        forward = "all" # Forward all cookies
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  # S3:store behavior (precedence default)
+  ordered_cache_behavior {
+    path_pattern     = "/store*"
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = aws_s3_bucket.wv_store_bucket.id
 
     forwarded_values {
       query_string = false
@@ -51,16 +114,23 @@ resource "aws_cloudfront_distribution" "fe_distribution" {
     max_ttl                = 86400
   }
 
-  price_class = "PriceClass_200"
+  # S3:customer behavior (default precedence)
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = aws_s3_bucket.wv_customer_bucket.id
 
-  restrictions {
-    geo_restriction {
-      restriction_type = "none"
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
     }
-  }
 
-  viewer_certificate {
-    acm_certificate_arn = aws_acm_certificate.global_cert.arn
-    ssl_support_method  = "sni-only"
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
   }
 }

--- a/cdn.tf
+++ b/cdn.tf
@@ -1,0 +1,50 @@
+resource "aws_cloudfront_origin_access_identity" "webview_distribution_oai" {
+}
+
+resource "aws_cloudfront_distribution" "webview_distribution" {
+  origin {
+    domain_name = aws_s3_bucket.webview_bucket.bucket_domain_name
+    origin_id   = aws_s3_bucket.webview_bucket.id
+    origin_path = "/customer"
+
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.webview_distribution_oai.cloudfront_access_identity_path
+    }
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  default_root_object = "index.html"
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = aws_s3_bucket.webview_bucket.id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+
+  price_class = "PriceClass_200"
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    # acm_certificate_arn = aws_acm_certificate.hz_main_cert.arn
+    cloudfront_default_certificate = true
+  }
+}

--- a/cdn.tf
+++ b/cdn.tf
@@ -21,6 +21,14 @@ resource "aws_cloudfront_origin_access_identity" "fe_customer_oai" {
 resource "aws_cloudfront_origin_access_identity" "fe_store_oai" {
 }
 
+## Functions
+resource "aws_cloudfront_function" "fe_func_replace_request_uri" {
+  name    = "elon-kiosk-cloudfront-function-replace-request-uri"
+  runtime = "cloudfront-js-1.0"
+  code    = file("./cloudfront-functions/replace-request-uri.js")
+}
+
+## Distributions
 resource "aws_cloudfront_distribution" "fe_distribution" {
   aliases = [format("elon-kiosk.%s", var.hz_main_name)]
   enabled             = true
@@ -102,6 +110,11 @@ resource "aws_cloudfront_distribution" "fe_distribution" {
       cookies {
         forward = "none"
       }
+    }
+
+    function_association {
+      event_type   = "viewer-request"
+      function_arn = aws_cloudfront_function.fe_func_replace_request_uri.arn
     }
 
     viewer_protocol_policy = "redirect-to-https"

--- a/cdn.tf
+++ b/cdn.tf
@@ -22,6 +22,7 @@ resource "aws_cloudfront_origin_access_identity" "fe_store_oai" {
 }
 
 resource "aws_cloudfront_distribution" "fe_distribution" {
+  aliases = [format("elon-kiosk.%s", var.hz_main_name)]
   enabled             = true
   is_ipv6_enabled     = true
   default_root_object = "index.html"

--- a/cdn.tf
+++ b/cdn.tf
@@ -144,4 +144,17 @@ resource "aws_cloudfront_distribution" "fe_distribution" {
     default_ttl            = 3600
     max_ttl                = 86400
   }
+
+  # SPA support: 404 handling
+  custom_error_response {
+    error_code = 404
+    response_code = 200
+    response_page_path = "/index.html"
+  }
+
+  custom_error_response {
+    error_code = 403
+    response_code = 200
+    response_page_path = "/index.html"
+  }
 }

--- a/cdn.tf
+++ b/cdn.tf
@@ -25,7 +25,6 @@ resource "aws_cloudfront_distribution" "fe_distribution" {
   aliases = [format("elon-kiosk.%s", var.hz_main_name)]
   enabled             = true
   is_ipv6_enabled     = true
-  default_root_object = "index.html"
   price_class = "PriceClass_200"
 
   restrictions {
@@ -39,27 +38,10 @@ resource "aws_cloudfront_distribution" "fe_distribution" {
     ssl_support_method  = "sni-only"
   }
 
-  # S3 Origin: customer webview bucket
-  origin {
-    domain_name = aws_s3_bucket.wv_customer_bucket.bucket_domain_name
-    origin_id   = aws_s3_bucket.wv_customer_bucket.id
-
-    s3_origin_config {
-      origin_access_identity = aws_cloudfront_origin_access_identity.fe_customer_oai.cloudfront_access_identity_path
-    }
-  }
-
-  # S3 Origin: store webview bucket
-  origin {
-    domain_name = aws_s3_bucket.wv_store_bucket.bucket_domain_name
-    origin_id   = aws_s3_bucket.wv_store_bucket.id
-
-    s3_origin_config {
-      origin_access_identity = aws_cloudfront_origin_access_identity.fe_store_oai.cloudfront_access_identity_path
-    }
-  }
-
-  # ALB origin
+  #############################################
+  # Precedence 0) ALB
+  #############################################
+  # Origin
   origin {
     domain_name = aws_alb.alb_main.dns_name
     origin_id   = aws_alb.alb_main.id
@@ -72,7 +54,7 @@ resource "aws_cloudfront_distribution" "fe_distribution" {
     }
   }
 
-  # ALB behavior (precedence 0)
+  # Behavior
   ordered_cache_behavior {
     path_pattern     = "/api*"
     allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
@@ -94,7 +76,20 @@ resource "aws_cloudfront_distribution" "fe_distribution" {
     viewer_protocol_policy = "redirect-to-https"
   }
 
-  # S3:store behavior (precedence default)
+  #############################################
+  # Precedence 1) S3:store webview bucket
+  #############################################
+  # Origin
+  origin {
+    domain_name = aws_s3_bucket.wv_store_bucket.bucket_domain_name
+    origin_id   = aws_s3_bucket.wv_store_bucket.id
+
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.fe_store_oai.cloudfront_access_identity_path
+    }
+  }
+
+  # Behavior
   ordered_cache_behavior {
     path_pattern     = "/store*"
     allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
@@ -115,7 +110,22 @@ resource "aws_cloudfront_distribution" "fe_distribution" {
     max_ttl                = 86400
   }
 
-  # S3:customer behavior (default precedence)
+  #############################################
+  # Default precedence) S3:customer webview bucket
+  #############################################
+  default_root_object = "index.html"
+
+  # Origin
+  origin {
+    domain_name = aws_s3_bucket.wv_customer_bucket.bucket_domain_name
+    origin_id   = aws_s3_bucket.wv_customer_bucket.id
+
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.fe_customer_oai.cloudfront_access_identity_path
+    }
+  }
+
+  # Behavior
   default_cache_behavior {
     allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
     cached_methods   = ["GET", "HEAD"]

--- a/cdn.tf
+++ b/cdn.tf
@@ -85,24 +85,24 @@ resource "aws_cloudfront_distribution" "fe_distribution" {
   }
 
   #############################################
-  # Precedence 1) S3:store webview bucket
+  # Precedence 1) S3:customer webview bucket
   #############################################
   # Origin
   origin {
-    domain_name = aws_s3_bucket.wv_store_bucket.bucket_domain_name
-    origin_id   = aws_s3_bucket.wv_store_bucket.id
+    domain_name = aws_s3_bucket.wv_customer_bucket.bucket_domain_name
+    origin_id   = aws_s3_bucket.wv_customer_bucket.id
 
     s3_origin_config {
-      origin_access_identity = aws_cloudfront_origin_access_identity.fe_store_oai.cloudfront_access_identity_path
+      origin_access_identity = aws_cloudfront_origin_access_identity.fe_customer_oai.cloudfront_access_identity_path
     }
   }
 
   # Behavior
   ordered_cache_behavior {
-    path_pattern     = "/store*"
+    path_pattern     = "/store*" # Use "/store" prefix to make URL path like "/store/$STORE_ID"
     allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
     cached_methods   = ["GET", "HEAD"]
-    target_origin_id = aws_s3_bucket.wv_store_bucket.id
+    target_origin_id = aws_s3_bucket.wv_customer_bucket.id
 
     forwarded_values {
       query_string = false
@@ -124,17 +124,17 @@ resource "aws_cloudfront_distribution" "fe_distribution" {
   }
 
   #############################################
-  # Default precedence) S3:customer webview bucket
+  # Default precedence) S3:store webview bucket
   #############################################
   default_root_object = "index.html"
 
   # Origin
   origin {
-    domain_name = aws_s3_bucket.wv_customer_bucket.bucket_domain_name
-    origin_id   = aws_s3_bucket.wv_customer_bucket.id
+    domain_name = aws_s3_bucket.wv_store_bucket.bucket_domain_name
+    origin_id   = aws_s3_bucket.wv_store_bucket.id
 
     s3_origin_config {
-      origin_access_identity = aws_cloudfront_origin_access_identity.fe_customer_oai.cloudfront_access_identity_path
+      origin_access_identity = aws_cloudfront_origin_access_identity.fe_store_oai.cloudfront_access_identity_path
     }
   }
 
@@ -142,7 +142,7 @@ resource "aws_cloudfront_distribution" "fe_distribution" {
   default_cache_behavior {
     allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
     cached_methods   = ["GET", "HEAD"]
-    target_origin_id = aws_s3_bucket.wv_customer_bucket.id
+    target_origin_id = aws_s3_bucket.wv_store_bucket.id
 
     forwarded_values {
       query_string = false

--- a/cloudfront-functions/replace-request-uri.js
+++ b/cloudfront-functions/replace-request-uri.js
@@ -1,0 +1,11 @@
+function handler(event) {
+    var request = event.request;
+    var uri = request.uri;
+
+    // Check whether the URI is missing a file extension.
+    if (!uri.includes('.')) {
+        request.uri = '/store/index.html';
+    }
+
+    return request;
+}

--- a/dns.tf
+++ b/dns.tf
@@ -58,14 +58,14 @@ resource "aws_acm_certificate_validation" "hz_main_cert_validate" {
 }
 
 ## ALB Alias Record
-resource "aws_route53_record" "hz_main_record_alb" {
+resource "aws_route53_record" "hz_main_record_cdn" {
   zone_id = aws_route53_zone.hz_main.zone_id
   name    = format("elon-kiosk.%s", var.hz_main_name)
   type    = "A"
 
   alias {
-    name                   = aws_alb.alb_main.dns_name
-    zone_id                = aws_alb.alb_main.zone_id
+    name                   = aws_cloudfront_distribution.fe_distribution.domain_name
+    zone_id                = aws_cloudfront_distribution.fe_distribution.hosted_zone_id
     evaluate_target_health = true
   }
 }

--- a/provider.tf
+++ b/provider.tf
@@ -17,3 +17,8 @@ terraform {
 provider "aws" {
   region = "ap-northeast-2"
 }
+
+provider "aws" {
+  alias   = "virginia"
+  region  = "us-east-1"
+}

--- a/provider.tf
+++ b/provider.tf
@@ -19,6 +19,6 @@ provider "aws" {
 }
 
 provider "aws" {
-  alias   = "virginia"
-  region  = "us-east-1"
+  alias  = "virginia"
+  region = "us-east-1"
 }

--- a/s3.tf
+++ b/s3.tf
@@ -1,29 +1,58 @@
 # Webview bucket
-resource "aws_s3_bucket" "webview_bucket" {
-  bucket = "elon-kiosk-webview-bucket"
+## Customer
+resource "aws_s3_bucket" "wv_customer_bucket" {
+  bucket = "elon-kiosk-webview-customer-bucket"
 }
 
-## Bucket ACL setting
-resource "aws_s3_bucket_acl" "webview_bucket_acl" {
-  bucket = aws_s3_bucket.webview_bucket.id
+### Bucket ACL setting
+resource "aws_s3_bucket_acl" "wv_customer_bucket_acl" {
+  bucket = aws_s3_bucket.wv_customer_bucket.id
   acl = "private"
 }
 
-data "aws_iam_policy_document" "webview_bucket_policy" {
+data "aws_iam_policy_document" "wv_customer_bucket_policy" {
   statement {
     actions   = ["s3:GetObject"]
-    resources = ["${aws_s3_bucket.webview_bucket.arn}/*"]
+    resources = ["${aws_s3_bucket.wv_customer_bucket.arn}/*"]
 
     principals {
       type        = "AWS"
-      identifiers = [aws_cloudfront_origin_access_identity.fe_oai.iam_arn]
+      identifiers = [aws_cloudfront_origin_access_identity.fe_customer_oai.iam_arn]
     }
   }
 }
 
-resource "aws_s3_bucket_policy" "webview_bucket_policy" {
-  bucket = aws_s3_bucket.webview_bucket.id
-  policy = data.aws_iam_policy_document.webview_bucket_policy.json
+resource "aws_s3_bucket_policy" "wv_customer_bucket_policy" {
+  bucket = aws_s3_bucket.wv_customer_bucket.id
+  policy = data.aws_iam_policy_document.wv_customer_bucket_policy.json
+}
+
+## Store
+resource "aws_s3_bucket" "wv_store_bucket" {
+  bucket = "elon-kiosk-webview-store-bucket"
+}
+
+### Bucket ACL setting
+resource "aws_s3_bucket_acl" "wv_store_bucket_acl" {
+  bucket = aws_s3_bucket.wv_store_bucket.id
+  acl = "private"
+}
+
+data "aws_iam_policy_document" "wv_store_bucket_policy" {
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.wv_store_bucket.arn}/*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [aws_cloudfront_origin_access_identity.fe_store_oai.iam_arn]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "wv_store_bucket_policy" {
+  bucket = aws_s3_bucket.wv_store_bucket.id
+  policy = data.aws_iam_policy_document.wv_store_bucket_policy.json
 }
 
 # Menu image bucket

--- a/s3.tf
+++ b/s3.tf
@@ -1,7 +1,32 @@
+# Webview bucket
 resource "aws_s3_bucket" "webview_bucket" {
   bucket = "elon-kiosk-webview-bucket"
 }
 
+## Bucket ACL setting
+resource "aws_s3_bucket_acl" "webview_bucket_acl" {
+  bucket = aws_s3_bucket.webview_bucket.id
+  acl = "private"
+}
+
+data "aws_iam_policy_document" "webview_bucket_policy" {
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.webview_bucket.arn}/*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [aws_cloudfront_origin_access_identity.webview_distribution_oai.iam_arn]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "webview_bucket_policy" {
+  bucket = aws_s3_bucket.webview_bucket.id
+  policy = data.aws_iam_policy_document.webview_bucket_policy.json
+}
+
+# Menu image bucket
 resource "aws_s3_bucket" "menu_img_bucket" {
   bucket = "elon-kiosk-menu-img-bucket"
 }

--- a/s3.tf
+++ b/s3.tf
@@ -16,7 +16,7 @@ data "aws_iam_policy_document" "webview_bucket_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = [aws_cloudfront_origin_access_identity.webview_distribution_oai.iam_arn]
+      identifiers = [aws_cloudfront_origin_access_identity.fe_oai.iam_arn]
     }
   }
 }

--- a/s3.tf
+++ b/s3.tf
@@ -7,7 +7,7 @@ resource "aws_s3_bucket" "wv_customer_bucket" {
 ### Bucket ACL setting
 resource "aws_s3_bucket_acl" "wv_customer_bucket_acl" {
   bucket = aws_s3_bucket.wv_customer_bucket.id
-  acl = "private"
+  acl    = "private"
 }
 
 data "aws_iam_policy_document" "wv_customer_bucket_policy" {
@@ -35,7 +35,7 @@ resource "aws_s3_bucket" "wv_store_bucket" {
 ### Bucket ACL setting
 resource "aws_s3_bucket_acl" "wv_store_bucket_acl" {
   bucket = aws_s3_bucket.wv_store_bucket.id
-  acl = "private"
+  acl    = "private"
 }
 
 data "aws_iam_policy_document" "wv_store_bucket_policy" {


### PR DESCRIPTION
## New features

- CloudFront distribution + Certificate
- Distribution origins and behaviors
    - `/api*` for ALB origin
    - `/store*` for customer-side UI
    - `*` for store-side UI
- SPA settings for static hosting origins

## Modifications

- Separated buckets for customer and store-side UI
- Modified Route53 record to point to CloudFront distribution

## Related issue

- Closes #11 